### PR TITLE
refactor: make FileHelper static

### DIFF
--- a/src/FileHelper.java
+++ b/src/FileHelper.java
@@ -2,7 +2,7 @@ import java.io.File;
 import java.io.IOException;
 
 public class FileHelper {
-    public String getExtension(String fileName){
+    public static String getExtension(String fileName){
         String extension = "";
         int i = fileName.lastIndexOf('.');
         if (i >= 0) {
@@ -11,7 +11,7 @@ public class FileHelper {
         return extension;
     }
 
-    public File getFile(String path) throws IOException {
+    public static File getFile(String path) throws IOException {
         File f = new File(path);
         f.getParentFile().mkdirs();
         f.createNewFile();

--- a/src/HTMLCollector.java
+++ b/src/HTMLCollector.java
@@ -6,11 +6,9 @@ import java.io.IOException;
 
 public class HTMLCollector {
     private final XMLParser xmlParser;
-    private final FileHelper fileHelper;
     private final HTMLParser htmlParser;
 
-    public HTMLCollector(FileHelper fileHelper, XMLParser xmlParser, HTMLParser htmlParser){
-        this.fileHelper = fileHelper;
+    public HTMLCollector(XMLParser xmlParser, HTMLParser htmlParser){
         this.htmlParser = htmlParser;
         this.xmlParser = xmlParser;
     }
@@ -25,7 +23,7 @@ public class HTMLCollector {
 
         int docId = 0;
         for(File html: contents){
-            if (fileHelper.getExtension(html.getName()).equals(".html")) continue;
+            if (FileHelper.getExtension(html.getName()).equals(".html")) continue;
             appendElement(document, docId++, html);
         }
         return document;

--- a/src/Main.java
+++ b/src/Main.java
@@ -16,17 +16,15 @@ public class Main {
         switch (command) {
             case "-c" -> {
                 HTMLParser htmlParser = new HTMLParser();
-                FileHelper fileHelper = new FileHelper();
-                XMLParser xmlParser = new XMLParser(fileHelper);
+                XMLParser xmlParser = new XMLParser();
 
-                HTMLCollector htmlCollector = new HTMLCollector(fileHelper, xmlParser, htmlParser);
+                HTMLCollector htmlCollector = new HTMLCollector( xmlParser, htmlParser);
                 Document collection = htmlCollector.collect(path);
                 xmlParser.saveXMLAs(collection, "./output/collection.xml");
                 System.out.println("Saved as ./output/collection.xml");
             }
             case "-k" -> {
-                FileHelper fileHelper = new FileHelper();
-                XMLParser xmlParser = new XMLParser(fileHelper);
+                XMLParser xmlParser = new XMLParser();
                 KeywordExtractor keywordExtractor = new KeywordExtractor();
 
                 WordAnalyzer wordAnalyzer = new WordAnalyzer(xmlParser, keywordExtractor);
@@ -35,9 +33,8 @@ public class Main {
                 System.out.println("Saved as ./output/index.xml");
             }
             case "-i" -> {
-                FileHelper fileHelper = new FileHelper();
-                XMLParser xmlParser = new XMLParser(fileHelper);
-                TFIDFHashMap tfidfHashMap = new TFIDFHashMap(fileHelper);
+                XMLParser xmlParser = new XMLParser();
+                TFIDFHashMap tfidfHashMap = new TFIDFHashMap();
 
                 Indexer indexer = new Indexer(xmlParser, tfidfHashMap);
                 indexer.calculateTFIDF(path);

--- a/src/TFIDFHashMap.java
+++ b/src/TFIDFHashMap.java
@@ -6,10 +6,8 @@ public class TFIDFHashMap {
     private final HashMap<String, ArrayList<Integer>> hashMap;
     private final HashMap<String, ArrayList<Double>> weightHashMap;
     private int size;
-    private final FileHelper fileHelper;
 
-    public TFIDFHashMap(FileHelper fileHelper){
-        this.fileHelper = fileHelper;
+    public TFIDFHashMap(){
         this.hashMap = new HashMap<>();
         this.weightHashMap = new HashMap<>();
     }
@@ -74,7 +72,7 @@ public class TFIDFHashMap {
     }
 
     public void dump(String path) throws IOException {
-        File f = fileHelper.getFile(path);
+        File f = FileHelper.getFile(path);
         FileOutputStream fileOutputStream = new FileOutputStream(f);
 
         ObjectOutputStream objectOutputStream = new ObjectOutputStream(fileOutputStream);

--- a/src/XMLParser.java
+++ b/src/XMLParser.java
@@ -15,20 +15,18 @@ import java.io.IOException;
 public class XMLParser {
     private final Transformer transformer;
     private final DocumentBuilder documentBuilder;
-    private final FileHelper fileHelper;
 
-    public XMLParser(FileHelper fileHelper) throws TransformerConfigurationException, ParserConfigurationException {
+    public XMLParser() throws TransformerConfigurationException, ParserConfigurationException {
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
         transformer = transformerFactory.newTransformer();
         DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
         documentBuilder = documentBuilderFactory.newDocumentBuilder();
-        this.fileHelper = fileHelper;
     }
 
     public void saveXMLAs(Document doc, String path) throws TransformerException, IOException {
         DOMSource src = new DOMSource(doc);
 
-        File f = fileHelper.getFile(path);
+        File f = FileHelper.getFile(path);
         StreamResult res = new StreamResult(new FileOutputStream(f));
 
         transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");


### PR DESCRIPTION
FileHelper에는 어떤 instance variable도 가지고 있지 않고, 그저 파일과 관련된 메서드를 수행할 때 코드 재활용을 위한 것입니다.
따라서 FileHelper의 메서드들을 static하게 만들고, 의존성을 제거합니다.